### PR TITLE
Fully clone SELECT queries

### DIFF
--- a/src/Select.php
+++ b/src/Select.php
@@ -47,7 +47,6 @@ class Select extends Query
     public function __clone()
     {
         $vars = get_object_vars($this);
-        unset($vars['bind']);
         foreach ($vars as $name => $prop) {
             if (is_object($prop)) {
                 $this->$name = clone $prop;


### PR DESCRIPTION
I'm not sure why the `bind` property is specifically excluded when cloning, however, the exclusion means that the original query becomes inconsistent between the statement and the bound parameters when the cloned query is modified, which is not expected behavior.

If there is a good reason for this behavior, it needs to be documented.