### PR TITLE
Backport fix for PHP 8.4 deprecation errors to 1.x

### DIFF
--- a/src/Insert.php
+++ b/src/Insert.php
@@ -32,7 +32,7 @@ class Insert extends Query
             . $this->returning->build();
     }
 
-    public function getLastInsertId(string $name = null)
+    public function getLastInsertId(?string $name = null)
     {
         return $this->connection->lastInsertId($name);
     }

--- a/tests/FakeConnection.php
+++ b/tests/FakeConnection.php
@@ -32,7 +32,7 @@ class FakeConnection extends Connection
         return new PDOStatement();
     }
 
-    public function lastInsertId(string $name = null) : string
+    public function lastInsertId(?string $name = null) : string
     {
         return "{$name}-1";
     }


### PR DESCRIPTION
Just the fix, nothing else.