### PR TITLE
Adjusments to run Atlas.Query with PHP 8.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,100 @@
+name: Atlas.Query CI
+
+on:
+  push:
+    paths-ignore:
+      - '**.md'
+      - '**.txt'
+  pull_request:
+    paths-ignore:
+      - '**.md'
+      - '**.txt'
+  workflow_dispatch:
+
+env:
+  fail-fast: true
+
+  # PHP extensions required by Composer
+  EXTENSIONS: pdo
+
+permissions:
+  contents: read
+
+jobs:
+
+  # PHPStan
+  quality:
+    name: "Validate Quality"
+    if: "!contains(github.event.head_commit.message, 'ci skip')"
+
+    permissions:
+      contents: read
+
+    runs-on: ubuntu-22.04
+
+    strategy:
+      fail-fast: true
+      matrix:
+        php:
+          - '8.0'
+          - '8.1'
+          - '8.2'
+          - '8.3'
+          - '8.4'
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: "Setup PHP"
+        uses: shivammathur/setup-php@2.35.3
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: ${{ env.EXTENSIONS }}
+        env:
+          COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: "Install development dependencies with Composer"
+        uses: "ramsey/composer-install@v3"
+        with:
+          composer-options: "--prefer-dist"
+
+      - name: "PHPStan"
+        run: |
+          composer stan
+
+  unit-tests:
+    needs: quality
+
+    permissions:
+      contents: read # to fetch code (actions/checkout)
+
+    name: Unit tests / PHP-${{ matrix.php }}
+    runs-on: ubuntu-22.04
+
+    strategy:
+      matrix:
+        php:
+          - '8.0'
+          - '8.1'
+          - '8.2'
+          - '8.3'
+          - '8.4'
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: "Setup PHP"
+        uses: shivammathur/setup-php@2.35.3
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: ${{ env.EXTENSIONS }}
+        env:
+          COMPOSER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: "Install development dependencies with Composer"
+        uses: "ramsey/composer-install@v3"
+        with:
+          composer-options: "--prefer-dist"
+
+      - name: "Run Unit Tests"
+        if: always()
+        run: |
+          composer test

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /composer.lock
 /vendor
 /.phpunit.result.cache
+/.bash_history
+.composer

--- a/src/Insert.php
+++ b/src/Insert.php
@@ -16,7 +16,7 @@ class Insert extends InsertStatement
 {
     use Query;
 
-    public function getLastInsertId(string $name = null) : string
+    public function getLastInsertId(?string $name = null) : string
     {
         return $this->connection->lastInsertId($name);
     }

--- a/src/Select.php
+++ b/src/Select.php
@@ -13,6 +13,7 @@ namespace Atlas\Query;
 use Atlas\Statement\Select as SelectStatement;
 use BadMethodCallException;
 use Generator;
+use PDO;
 
 /**
  * @method array|false fetchAll()

--- a/tests/DeleteTest.php
+++ b/tests/DeleteTest.php
@@ -10,6 +10,6 @@ namespace Atlas\Query;
 
 use PDOStatement;
 
-class DeleteTest extends QueryTest
+class DeleteTest extends QueryTestCase
 {
 }

--- a/tests/InsertTest.php
+++ b/tests/InsertTest.php
@@ -8,7 +8,7 @@
  */
 namespace Atlas\Query;
 
-class InsertTest extends QueryTest
+class InsertTest extends QueryTestCase
 {
     public function testGetLastInsertId()
     {

--- a/tests/QueryTestCase.php
+++ b/tests/QueryTestCase.php
@@ -10,8 +10,9 @@ namespace Atlas\Query;
 
 use PDOStatement;
 use Atlas\Query\Driver\FakeDriver;
+use PHPUnit\Framework\TestCase;
 
-abstract class QueryTest extends \PHPUnit\Framework\TestCase
+abstract class QueryTestCase extends TestCase
 {
     protected function getQueryClass()
     {

--- a/tests/SelectTest.php
+++ b/tests/SelectTest.php
@@ -11,7 +11,7 @@ namespace Atlas\Query;
 use BadMethodCallException;
 use Generator;
 
-class SelectTest extends QueryTest
+class SelectTest extends QueryTestCase
 {
     public function test__call()
     {

--- a/tests/UpdateTest.php
+++ b/tests/UpdateTest.php
@@ -10,6 +10,6 @@ namespace Atlas\Query;
 
 use PDOStatement;
 
-class UpdateTest extends QueryTest
+class UpdateTest extends QueryTestCase
 {
 }


### PR DESCRIPTION
- Added GitHub Actions setup to run the tests
- Renamed `QueryTest` to `QueryTestCase` to stop warnings from phpunit
- Changed `Insert::getLastInsertId(string $name = null)` to `getLastInsertId(?string $name = null)` (PHP 8.4)
- Added a couple of entries to .gitignore

